### PR TITLE
Add zen_mode to example config.ini for clarity

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -19,6 +19,7 @@ show_gifs_only = False
 show_path_in_tooltip = True
 number_of_columns = 3
 use_xdg_state = False
+zen_mode = False
 swww_transition_type = any
 swww_transition_step = 90
 swww_transition_angle = 0


### PR DESCRIPTION
This adds the `zen_mode` option to the example `config.ini` to make it easier for users to see that it's supported.